### PR TITLE
Removed database password environment variable and other minor fixes.

### DIFF
--- a/petclinic/Dockerfile
+++ b/petclinic/Dockerfile
@@ -2,4 +2,6 @@ FROM public.ecr.aws/bitnami/java:latest
 VOLUME /tmp
 ADD target/spring-petclinic-2.3.0.jar app.jar
 EXPOSE 80
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+RUN apt-get update
+RUN apt-get -y install awscli
+ENTRYPOINT env spring.datasource.password=$(aws ssm get-parameter --name /database/password --with-decrypt --region $AWS_REGION | grep Value | cut -d '"' -f4) java -Djava.security.egd=file:/dev/./urandom -jar /app.jar

--- a/terraform/codebuild.tf
+++ b/terraform/codebuild.tf
@@ -43,7 +43,10 @@ resource "aws_iam_policy" "codebuild_policy" {
         "s3:GetObject", "s3:GetObjectVersion", "s3:PutObject"
       ],
       "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.artifact_bucket.arn}/*"
+      "Resource": [
+        "${aws_s3_bucket.artifact_bucket.arn}/*",
+        "${aws_s3_bucket.cache.arn}/*"
+      ]
     },
     {
       "Action": [
@@ -80,6 +83,7 @@ resource "aws_iam_role_policy_attachment" "codebuild-attach" {
 resource "aws_s3_bucket" "cache" {
   bucket = var.codebuild_cache_bucket_name # workaround from https://github.com/hashicorp/terraform-provider-aws/issues/10195
   acl    = "private"
+  force_destroy = true
 }
 
 resource "aws_codebuild_project" "codebuild" {

--- a/terraform/codepipeline.tf
+++ b/terraform/codepipeline.tf
@@ -75,6 +75,7 @@ resource "aws_iam_role_policy_attachment" "codepipeline-attach" {
 }
 
 resource "aws_s3_bucket" "artifact_bucket" {
+  force_destroy = true
 }
 
 # CodePipeline 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -23,3 +23,39 @@ resource "aws_iam_role_policy_attachment" "apprunner-service-role-attachment" {
   role       = aws_iam_role.apprunner-service-role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
 }
+
+
+resource "aws_iam_role" "apprunner-instance-role" {
+  name = "${var.apprunner-service-role}AppRunnerInstanceRole"
+  path = "/"
+  assume_role_policy = data.aws_iam_policy_document.apprunner-instance-assume-policy.json
+}
+
+resource "aws_iam_policy" "Apprunner-policy" {
+  name = "Apprunner-getSSM"
+  policy = data.aws_iam_policy_document.apprunner-instance-role-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "apprunner-instance-role-attachment" {
+  role = aws_iam_role.apprunner-instance-role.name
+  policy_arn = aws_iam_policy.Apprunner-policy.arn
+}
+
+data "aws_iam_policy_document" "apprunner-instance-assume-policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+      identifiers = ["tasks.apprunner.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "apprunner-instance-role-policy" {
+  statement {
+    actions = ["ssm:GetParameter"]
+    effect = "Allow"
+    resources = ["arn:aws:ssm:*:${data.aws_caller_identity.current.account_id}:parameter${data.aws_ssm_parameter.dbpassword.name}"]
+  }
+}

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -13,8 +13,8 @@ resource "aws_apprunner_service" "service" {
       image_configuration {
         port = var.container_port
         runtime_environment_variables = {
+          "AWS_REGION" : "${var.aws_region}",
           "spring.datasource.username" : "${var.db_user}",
-          "spring.datasource.password" : "${data.aws_ssm_parameter.dbpassword.value}",
           "spring.datasource.initialization-mode" : var.db_initialize_mode,
           "spring.profiles.active" : var.db_profile,
           "spring.datasource.url" : "jdbc:mysql://${aws_db_instance.db.address}/${var.db_name}"
@@ -23,6 +23,9 @@ resource "aws_apprunner_service" "service" {
       image_identifier      = "${data.aws_ecr_repository.image_repo.repository_url}:latest"
       image_repository_type = "ECR"
     }
+  }
+  instance_configuration {
+    instance_role_arn = aws_iam_role.apprunner-instance-role.arn
   }
   depends_on = [aws_iam_role.apprunner-service-role, aws_db_instance.db, aws_route_table.private-route-table, null_resource.petclinic_springboot]
 }


### PR DESCRIPTION
* Update Dockerfile to use an Entrypoint that sets the `spring.datasource.password` environment variable from an aws-cli call to get the password from Parameter Store.
* Create an IAM role and attach a policy that allows for reading the password from the Parameter Store and configure App Runner to use that role for the application.
* Remove the App Runner Environment variable that provides the database password, and include a new variable `AWS_REGION` for use when fetching the password via the AWS CLI within the docker container.
* Expand the CodeBuild IAM policy to allow access to the Cache Bucket
* Add `force_destroy = true` to the S3 buckets so that `terraform destroy` will be able to delete a non-empty bucket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
