### PR TITLE
Utilize VPC Connector and Make RDS Private

### DIFF
--- a/terraform/codebuild.tf
+++ b/terraform/codebuild.tf
@@ -82,8 +82,12 @@ resource "aws_iam_role_policy_attachment" "codebuild-attach" {
 
 resource "aws_s3_bucket" "cache" {
   bucket = var.codebuild_cache_bucket_name # workaround from https://github.com/hashicorp/terraform-provider-aws/issues/10195
-  acl    = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "cache-bucket-acl" {
+  bucket = aws_s3_bucket.cache.id
+  acl    = "private"
 }
 
 resource "aws_codebuild_project" "codebuild" {

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -4,7 +4,7 @@
 resource "aws_db_subnet_group" "db-subnet-grp" {
   name        = "petclinic-db-sgrp"
   description = "Database Subnet Group"
-  subnet_ids  = aws_subnet.public.*.id
+  subnet_ids  = aws_subnet.private.*.id
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ resource "aws_db_instance" "db" {
   engine_version          = "5.7"
   port                    = "3306"
   instance_class          = var.db_instance_type
-  name                    = var.db_name
+  db_name                    = var.db_name
   username                = var.db_user
   password                = data.aws_ssm_parameter.dbpassword.value
   availability_zone       = "${var.aws_region}a"
@@ -26,7 +26,7 @@ resource "aws_db_instance" "db" {
   multi_az                = false
   db_subnet_group_name    = aws_db_subnet_group.db-subnet-grp.id
   parameter_group_name    = "default.mysql5.7"
-  publicly_accessible     = true
+  publicly_accessible     = false
   skip_final_snapshot     = true
   backup_retention_period = 0
 

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -18,7 +18,7 @@ resource "aws_db_instance" "db" {
   engine_version          = "5.7"
   port                    = "3306"
   instance_class          = var.db_instance_type
-  db_name                    = var.db_name
+  db_name                 = var.db_name
   username                = var.db_user
   password                = data.aws_ssm_parameter.dbpassword.value
   availability_zone       = "${var.aws_region}a"

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -11,7 +11,7 @@ resource "aws_security_group" "db-sg" {
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    security_groups = ["${aws_security_group.service-sg.id}"]
   }
 
   ingress {
@@ -30,5 +30,48 @@ resource "aws_security_group" "db-sg" {
 
   tags = {
     Name = "${var.stack}-db-sg"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# SECURITY GROUP FOR APPRUNNER
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group" "service-sg" {
+  name        = "${var.stack}-service-sg"
+  description = "Security gruop asspciated with the AppRunner service VPC connector"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+
+  ingress {
+    from_port   = 8
+    to_port     = 0
+    protocol    = "icmp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.stack}-service-sg"
   }
 }


### PR DESCRIPTION

*Description of changes:*
Added support for VPC Connector and disabled RDS public accessibility. 
Communications between AppRunner service(s) to the RDS will now stay within the VPC and RDS will be placed into private subnet. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
